### PR TITLE
remove entityDestroyed event

### DIFF
--- a/packages/server/index.d.ts
+++ b/packages/server/index.d.ts
@@ -1296,6 +1296,10 @@ declare interface EventMpThis {
 
 declare interface IServerEvents {
 	entityCreated: (this: EventMpThis, entity: EntityMp) => void;
+	/*
+         * @deprecated Broken/Removed in RageMP 1.1 DP1
+         */
+	entityDestroyed: (this: EventMpThis, entity: EntityMp) => void;
 	entityModelChange: (this: EventMpThis, entity: EntityMp, oldModel: number) => void;
 	incomingConnection: (this: EventMpThis, ip: string, serial: string, rgscName: string, rgscId: string, gameType: string) => void;
 	packagesLoaded: (this: EventMpThis) => void;

--- a/packages/server/index.d.ts
+++ b/packages/server/index.d.ts
@@ -1296,7 +1296,6 @@ declare interface EventMpThis {
 
 declare interface IServerEvents {
 	entityCreated: (this: EventMpThis, entity: EntityMp) => void;
-	entityDestroyed: (this: EventMpThis, entity: EntityMp) => void;
 	entityModelChange: (this: EventMpThis, entity: EntityMp, oldModel: number) => void;
 	incomingConnection: (this: EventMpThis, ip: string, serial: string, rgscName: string, rgscId: string, gameType: string) => void;
 	packagesLoaded: (this: EventMpThis) => void;

--- a/packages/server/index.d.ts
+++ b/packages/server/index.d.ts
@@ -1295,7 +1295,7 @@ declare interface EventMpThis {
 }
 
 declare interface IServerEvents {
-	entityCreated: (entity: EntityMp) => void;;
+	entityCreated: (entity: EntityMp) => void;
 	/*
  	 * @deprecated Broken/Removed in RageMP 1.1 DP1
 	 */


### PR DESCRIPTION
Doesn't work anymore in 1.1 and I don't think so it'll come back