### PR TITLE
testCapsule ignoreEntity array + getEntityIsFreeAimingAt

### DIFF
--- a/game/player.d.ts
+++ b/game/player.d.ts
@@ -206,6 +206,7 @@ declare interface GamePlayer extends GamePlayerLegacy {
 	stopTeleport(): void;
 	isTeleportActive(): boolean;
 	getCurrentStealthNoise(): number;
+	getEntityIsFreeAimingAt(): EntityMp | number | undefined;
 	setHealthRechargeMultiplier(regenRate: number): void;
 	getHealthRechargeLimit(): number;
 	setHealthRechargeLimit(limit: number): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -884,7 +884,7 @@ declare interface RaycastingMp {
 	/**
 	 * Raycast from point to point, where the ray has a radius.
 	 */
-	testCapsule(startPos: Vector3, endPos: Vector3, radius: number, ignoreEntity?: EntityMp, flags?: number | number[]): RaycastResult;
+	testCapsule(startPos: Vector3, endPos: Vector3, radius: number, ignoreEntity?: EntityMp | EntityMp[], flags?: number | number[]): RaycastResult;
 }
 
 declare interface RaycastResult {


### PR DESCRIPTION
https://wiki.rage.mp/index.php?title=Raycasting::testCapsule

`ignoreEntity: Array of entities handle or object`

https://wiki.rage.mp/index.php?title=Player::getEntityIsFreeAimingAt

`Returns RAGE:MP Object or World-Object Handle if it found an entity in your crosshair within range of your weapon..
Returns undefined if no entity found.`