### PR TITLE
Fix taskJump and Remove missing toArrayFast

### DIFF
--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -1999,7 +1999,12 @@ declare interface PedMpBase extends EntityMp {
 		p13: number,
 		p14: number
 	): void;
-	taskJump(unused: boolean): void;
+	/**
+	 * @param unused
+	 * @param flag1 - super jump
+	 * @param flag2 - do nothing if flag1 is false and doubles super jump height if flag1 is true.
+	 */
+	taskJump(unused: boolean, flag1: boolean, flag2: boolean): void;
 	taskLeaveAnyVehicle(p1: number, p2: number): void;
 	taskLeaveVehicle(vehicle: Handle, flags: number): void;
 	taskLookAt(lookAt: Handle, duration: number, unknown1: number, unknown2: number): void;

--- a/packages/server/index.d.ts
+++ b/packages/server/index.d.ts
@@ -351,14 +351,8 @@ declare class EntityMpPool<T> {
 	/**
 	 * Converts a pool to an array.
 	 *
-	 * If you don't need to create a new array every time, use [Pool::toArrayFast](https://wiki.rage.mp/index.php?title=Pool::toArrayFast).
 	 */
 	public toArray(): T[];
-
-	/**
-	 * Same as [Pool::toArray](https://wiki.rage.mp/index.php?title=Pool::toArray) except it doesn't create a new array each time and instead updates it and returns the same array.
-	 */
-	public toArrayFast(): T[];
 }
 
 declare class PlayerMp extends EntityMp {


### PR DESCRIPTION
### Fix PedMp taskJump definition
MulleDK19: Definition is wrong. This has 4 parameters (Not sure when they were added. v350 has 2, v678 has 4).

v350: Ped ped, bool unused
v678: Ped ped, bool unused, bool flag1, bool flag2

https://wiki.rage.mp/index.php?title=Player::taskJump
https://nativedb.dotindustries.dev/natives/0x0AE4086104E067B1

### Remove missing Pool::toArrayFast method in types-server
Pool::toArrayFast in types-client works fine

This method has been missing for a very long time
and is unlikely to be added again: https://i.imgur.com/7sl0qU1.png