### PR TITLE
chore: Updates to game audio / voiceChat typings

### DIFF
--- a/packages/client/game/audio.d.ts
+++ b/packages/client/game/audio.d.ts
@@ -352,6 +352,12 @@ declare interface GameAudio extends GameAudioLegacy {
 	setVehicleHornVariation(vehicle: number, value: number): void;
 	playPoliceCrimeReport(position: Vector3, crimeIndex: number, playDelay: number, localPlayer: boolean): void;
 	unk: GameAudioUnk;
+
+	getCategoryVariable(categoryHash: number, fieldNameHash: number): void;
+	setCategoryVariable(categoryHash: number, fieldNameHash: number, value: any): void;
+	copyCategoryVariables(categoryTo: number, categoryFrom: number): void;
+	restoreCategoryVariables(categoryHash: number): void;
+
 }
 
 declare interface GameAudioMp extends GameAudio { }

--- a/packages/client/game/audio.d.ts
+++ b/packages/client/game/audio.d.ts
@@ -357,7 +357,6 @@ declare interface GameAudio extends GameAudioLegacy {
 	setCategoryVariable(categoryHash: number, fieldNameHash: number, value: any): void;
 	copyCategoryVariables(categoryTo: number, categoryFrom: number): void;
 	restoreCategoryVariables(categoryHash: number): void;
-
 }
 
 declare interface GameAudioMp extends GameAudio { }

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -994,6 +994,20 @@ declare interface VoiceChatMp {
 	setPreprocessingParam(setting: number, value: any): void;
 
 	cleanupAndReload(p0: boolean, p1: boolean, p2: boolean): void;
+
+	/**
+	 * Disabled by default.
+	 * @example
+	 * mp.voiceChat.gameOutputEnabled = true;
+	 */
+	gameOutputEnabled: boolean;
+
+	/**
+	 * Default value is set to 'mp.game.joaat('SPEECH_SCRIPTED')'
+	 * @example
+	 * mp.voiceChat.gameOutputCategory = hash;
+	 */
+	gameOutputCategory: number;
 }
 
 declare interface RaycastingMp {

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -1008,6 +1008,12 @@ declare interface VoiceChatMp {
 	 * mp.voiceChat.gameOutputCategory = hash;
 	 */
 	gameOutputCategory: number;
+
+	advancedNoiseSuppression: boolean;
+
+	networkOptimisations: boolean;
+
+	bitrate: number;
 }
 
 declare interface RaycastingMp {

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -2372,6 +2372,8 @@ declare interface PlayerMp extends PedMpBase {
 	voiceAutoVolume: boolean;
 	voiceVolume: number;
 	voice3d: any;
+	voiceGameOutputEnabled: boolean;
+	voiceGameOutputCategory: number;
 
 	readonly action: string;
 	readonly aimTarget: boolean;
@@ -2487,6 +2489,7 @@ declare interface PlayerMp extends PedMpBase {
 	setVehicleDamageModifier(damageAmount: number): void;
 	setVehicleDefenseModifier(modifier: number): void;
 	setVoiceAttribute(attribute: any, value: any): void; // TODO
+	closeVoiceStream(): void;
 	setWantedCentrePosition(x: number, y: number, z: number): void;
 	setWantedLevel(wantedLevel: number, disableNoMission: boolean): void;
 	setWantedLevelNoDrop(wantedLevel: number, p2: boolean): void;


### PR DESCRIPTION
This covers the remaining updates to voice chat/audio that were introduced here:

[https://rage.mp/forums/topic/24461-voice-chat-improvements-new-entity-graphics-and-blips-api#Blip_API_Updates](https://rage.mp/forums/topic/24461-voice-chat-improvements-new-entity-graphics-and-blips-api#Blip_API_Updates)

There is no documentation on the wiki for:
```typescript
	advancedNoiseSuppression: boolean;

	networkOptimisations: boolean;

	bitrate: number;
```
or:

(PlayerMp):

```
	voiceGameOutputEnabled: boolean;
	voiceGameOutputCategory: number;

	closeVoiceStream(): void;
```
