### PR TITLE
chore: Add missing R* Editor update typings

### DIFF
--- a/packages/client/game/replay.d.ts
+++ b/packages/client/game/replay.d.ts
@@ -10,6 +10,10 @@ declare interface GameReplay {
 	activateRockstarEditor(): void;
 
 	unk: GameReplayUnk;
+
+	continueTransition(): void;
+
+	isEditorAvailable(): boolean;
 }
 
 declare interface GameReplayMp extends GameReplay {}

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -344,7 +344,7 @@ declare interface KeysMp {
 }
 
 declare interface StorageMp {
-	/** Keeps data saved over resource reloads, but is cleared on reconnect.
+	/** Keeps data saved over resource reloads, and is persistent between reconnections to the same server during a single session.
 	 */
 	sessionData: unknown;
 
@@ -1149,6 +1149,7 @@ declare interface IClientEvents {
 	dummyEntityCreated: (dummyType: number, dummy: DummyEntityMp) => void;
 	dummyEntityDestroyed: (dummyType: number, dummy: DummyEntityMp) => void;
 	entityControllerChange: (entity: EntityMp, newController: PlayerMp) => void;
+	replayEditorRequest: () => void;
 	incomingDamage: (
 		sourceEntity: EntityMp,
 		sourcePlayer: PlayerMp,


### PR DESCRIPTION
These were some missing functions/events that I found that were added in this update:
[R* Editor Is Coming To RAGE Multiplayer](https://rage.mp/forums/topic/24363-r-editor-is-coming-to-rage-multiplayer/)

As per that post, 'Client-side mp.storage.sessionData is now persistent between reconnections to the same server during a single session (R* Editor included)'