### PR TITLE
player.allWeapons is a key-value pair, not an array of numbers

### DIFF
--- a/packages/server/index.d.ts
+++ b/packages/server/index.d.ts
@@ -371,7 +371,7 @@ declare class PlayerMp extends EntityMp {
 	/**
 	 * Property used for getting the player's weapon hash and ammo.
 	 */
-	public readonly allWeapons: number[];
+	public readonly allWeapons: Record<number, number>;
 
 	/**
 	 * Property used for getting the player's ip address.


### PR DESCRIPTION
There is a type error; In the Wiki (https://wiki.rage.mp/wiki/Player::allWeapons), it states that `allWeapons` is a key-value pair.

Found when attempting to loop over earlier today.
```player.allWeapons.map is not a function - TypeError: player.allWeapons.map is not a function```