### PR TITLE
Return camera.d.ts

### DIFF
--- a/packages/client/enums/camera.d.ts
+++ b/packages/client/enums/camera.d.ts
@@ -1,0 +1,33 @@
+declare namespace RageEnums.Camera {
+    enum GraphTypes {
+        TYPE_LINEAR = 0,
+        TYPE_SIN_ACCEL_DECEL,
+        TYPE_ACCEL,
+        TYPE_DECEL,
+        TYPE_SLOW_IN,
+        TYPE_SLOW_OUT,
+        TYPE_SLOW_IN_OUT,
+        TYPE_VERY_SLOW_IN,
+        TYPE_VERY_SLOW_OUT,
+        TYPE_VERY_SLOW_IN_SLOW_OUT,
+        TYPE_SLOW_IN_VERY_SLOW_OUT,
+        TYPE_VERY_SLOW_IN_VERY_SLOW_OUT,
+        TYPE_EASE_IN,
+        TYPE_EASE_OUT,
+        TYPE_QUADRATIC_EASE_IN,
+        TYPE_QUADRATIC_EASE_OUT,
+        TYPE_QUADRATIC_EASE_IN_OUT,
+        TYPE_CUBIC_EASE_IN,
+        TYPE_CUBIC_EASE_OUT,
+        TYPE_CUBIC_EASE_IN_OUT,
+        TYPE_QUARTIC_EASE_IN,
+        TYPE_QUARTIC_EASE_OUT,
+        TYPE_QUARTIC_EASE_IN_OUT,
+        TYPE_QUINTIC_EASE_IN,
+        TYPE_QUINTIC_EASE_OUT,
+        TYPE_QUINTIC_EASE_IN_OUT,
+        TYPE_CIRCULAR_EASE_IN,
+        TYPE_CIRCULAR_EASE_OUT,
+        TYPE_CIRCULAR_EASE_IN_OUT
+    }
+}


### PR DESCRIPTION
It seems that it was deleted by mistake in: https://github.com/ragempcommunity/ragemp-types/commit/c531877deb1f691aa25c0a718687fcbcd2e57514

As there's still reference in https://github.com/ragempcommunity/ragemp-types/blob/650db47f9ddebe2aad735a50dd8477e2d6dcb33f/packages/client/enums.d.ts#L7